### PR TITLE
Profile tab/ym

### DIFF
--- a/components/Bio.js
+++ b/components/Bio.js
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function Bio() {
+  return (
+    <div>
+      <p>Bio</p>
+    </div>
+  );
+}

--- a/components/Bio.js
+++ b/components/Bio.js
@@ -1,9 +1,21 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import ProfileDetailCard from './ProfileDetailCard';
+import { getSingleProfile } from '../api/profileData';
 
 export default function Bio() {
+  const [userProfile, setUserProfile] = useState({});
+  const router = useRouter();
+  const { uid } = router.query;
+
+  useEffect(() => {
+    getSingleProfile(uid).then(setUserProfile);
+  }, [uid]);
+
   return (
     <div>
-      <p>Bio</p>
+      <ProfileDetailCard profileObj={userProfile} />
+
     </div>
   );
 }

--- a/components/ProfileCard.js
+++ b/components/ProfileCard.js
@@ -14,7 +14,7 @@ export default function ProfileCard({ profileObj }) {
     >
       <div><img
         style={{
-          width: '100px', height: '100px', borderRadius: '80%', marginTop: '20px',
+          width: '100px', height: '100px', borderRadius: '50%', marginTop: '20px', objectFit: 'cover',
         }}
         src={profileObj.image}
         alt="profile-pic"

--- a/components/ProfileCard.js
+++ b/components/ProfileCard.js
@@ -44,6 +44,7 @@ export default function ProfileCard({ profileObj }) {
           : (
             <button
               type="button"
+              onClick={() => router.push(`profile/${profileObj.uid}`)}
               style={{
                 color: 'white', fontSize: '10px', width: '130px', height: '30px', backgroundColor: '#3F525B', border: 'none', borderRadius: '20px', display: 'flex', justifyContent: 'space-between', alignItems: 'center', margin: '15px', padding: '10px',
               }}

--- a/components/ProfileCard.js
+++ b/components/ProfileCard.js
@@ -44,7 +44,7 @@ export default function ProfileCard({ profileObj }) {
           : (
             <button
               type="button"
-              onClick={() => router.push(`profile/${profileObj.uid}`)}
+              onClick={() => router.push(`discover/${profileObj.uid}`)}
               style={{
                 color: 'white', fontSize: '10px', width: '130px', height: '30px', backgroundColor: '#3F525B', border: 'none', borderRadius: '20px', display: 'flex', justifyContent: 'space-between', alignItems: 'center', margin: '15px', padding: '10px',
               }}

--- a/components/ProfileDetailCard.js
+++ b/components/ProfileDetailCard.js
@@ -10,6 +10,7 @@ export default function ProfileDetailCard({ profileObj }) {
         <div className="profile-card__text-container">
           <h2 className="profile-card__name">{profileObj.name}</h2>
           <p className="profile-card__skill">{profileObj.skill}</p>
+          <p className="profile-card__location">{profileObj.location}</p>
         </div>
       </div>
       <div className="profile-card__bio">
@@ -27,5 +28,6 @@ ProfileDetailCard.propTypes = {
     name: PropTypes.string,
     skill: PropTypes.string,
     bio: PropTypes.string,
+    location: PropTypes.string,
   }).isRequired,
 };

--- a/components/ProfileDetailCard.js
+++ b/components/ProfileDetailCard.js
@@ -1,0 +1,31 @@
+/* eslint-disable @next/next/no-img-element */
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export default function ProfileDetailCard({ profileObj }) {
+  return (
+    <div className="profile-detail-body">
+      <div className="profile-card">
+        <img src={profileObj.image} alt="profile pic" className="profile-card__image" />
+        <div className="profile-card__text-container">
+          <h2 className="profile-card__name">{profileObj.name}</h2>
+          <p className="profile-card__skill">{profileObj.skill}</p>
+        </div>
+      </div>
+      <div className="profile-card__bio">
+        <div className="profile-card__bio-content">
+          <p>{profileObj.bio}</p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+ProfileDetailCard.propTypes = {
+  profileObj: PropTypes.shape({
+    image: PropTypes.string,
+    name: PropTypes.string,
+    skill: PropTypes.string,
+    bio: PropTypes.string,
+  }).isRequired,
+};

--- a/components/ProfileTab.js
+++ b/components/ProfileTab.js
@@ -1,0 +1,50 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+
+export default function ProfileTab({ children }) {
+  const [activeTab, setActiveTab] = useState('Bio');
+
+  const handleClick = (tab) => {
+    setActiveTab(tab);
+  };
+
+  return (
+    <div>
+      <div style={{
+        borderBottom: 'solid black', width: '40%', borderWidth: '1.8px', alignContent: 'center', display: 'block', marginLeft: 'auto', marginRight: 'auto', marginTop: '50px',
+      }}
+      >
+        <button
+          type="button"
+          className="tab-button"
+          onClick={() => handleClick('Bio')}
+          style={{
+            backgroundColor: 'inherit', color: 'black', padding: '10px 15px', borderWidth: '0px',
+          }}
+        > Bio
+        </button>
+        <button
+          type="button"
+          className="tab-button"
+          onClick={() => handleClick('Review')}
+          style={{
+            backgroundColor: 'inherit', color: 'black', padding: '10px 15px', borderWidth: '0px',
+          }}
+        > Review
+        </button>
+      </div>
+      <div>
+        {children.map((child) => {
+          if (child.props.label === activeTab) {
+            return child;
+          }
+          return null;
+        })}
+      </div>
+    </div>
+  );
+}
+
+ProfileTab.propTypes = {
+  children: PropTypes.arrayOf(PropTypes.element).isRequired,
+};

--- a/components/ProfileTab.js
+++ b/components/ProfileTab.js
@@ -11,12 +11,12 @@ export default function ProfileTab({ children }) {
   return (
     <div>
       <div style={{
-        borderBottom: 'solid black', width: '40%', borderWidth: '1.8px', alignContent: 'center', display: 'block', marginLeft: 'auto', marginRight: 'auto', marginTop: '50px',
+        width: '40%', borderWidth: '1.8px', alignContent: 'center', display: 'block', marginLeft: 'auto', marginRight: 'auto', marginTop: '50px',
       }}
       >
         <button
           type="button"
-          className="tab-button"
+          className={activeTab === 'Bio' ? 'tab-button' : ''}
           onClick={() => handleClick('Bio')}
           style={{
             backgroundColor: 'inherit', color: 'black', padding: '10px 15px', borderWidth: '0px',
@@ -25,7 +25,7 @@ export default function ProfileTab({ children }) {
         </button>
         <button
           type="button"
-          className="tab-button"
+          className={activeTab === 'Review' ? 'tab-button' : ''}
           onClick={() => handleClick('Review')}
           style={{
             backgroundColor: 'inherit', color: 'black', padding: '10px 15px', borderWidth: '0px',

--- a/components/Review.js
+++ b/components/Review.js
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function Review() {
+  return (
+    <div>
+      <p>review</p>
+    </div>
+  );
+}

--- a/components/Tab.js
+++ b/components/Tab.js
@@ -1,0 +1,55 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+
+export default function Tab({ children }) {
+  const [activeTab, setActiveTab] = useState('Bio');
+
+  const handleClick = (tab) => {
+    setActiveTab(tab);
+  };
+
+  const handleKeyDown = (event, tab) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      setActiveTab(tab);
+    }
+  };
+
+  return (
+    <div className="tab">
+      <div className="tab-headers">
+        <div
+          className={`tab-header ${activeTab === 'Bio' ? 'active' : 'hover-header'}`}
+          onClick={() => handleClick('Bio')}
+          onKeyDown={(e) => handleKeyDown(e, 'Bio')}
+          tabIndex={0}
+          role="tab"
+          aria-selected={activeTab === 'Bio'}
+        >
+          Bio
+        </div>
+        <div
+          className={`tab-header ${activeTab === 'Review' ? 'active' : 'hover-header'}`}
+          onClick={() => handleClick('Review')}
+          onKeyDown={(e) => handleKeyDown(e, 'Bio')}
+          tabIndex={0}
+          role="tab"
+          aria-selected={activeTab === 'Bio'}
+        >
+          Review
+        </div>
+      </div>
+      <div className="tab-body">
+        {children.map((child) => {
+          if (child.props.label === activeTab) {
+            return child;
+          }
+          return null;
+        })}
+      </div>
+    </div>
+  );
+}
+
+Tab.propTypes = {
+  children: PropTypes.arrayOf(PropTypes.element).isRequired,
+};

--- a/pages/discover/[uid].js
+++ b/pages/discover/[uid].js
@@ -1,10 +1,15 @@
 import React from 'react';
 import ProfileTab from '../../components/ProfileTab';
+import Bio from '../../components/Bio';
+import Review from '../../components/Review';
 
 export default function ProfileDeatil() {
   return (
     <div>
-      <ProfileTab />
+      <ProfileTab>
+        <Bio label="Bio" />
+        <Review label="Review" />
+      </ProfileTab>
     </div>
   );
 }

--- a/pages/discover/[uid].js
+++ b/pages/discover/[uid].js
@@ -1,0 +1,10 @@
+import React from 'react';
+import ProfileTab from '../../components/ProfileTab';
+
+export default function ProfileDeatil() {
+  return (
+    <div>
+      <ProfileTab />
+    </div>
+  );
+}

--- a/pages/discover/[uid].js
+++ b/pages/discover/[uid].js
@@ -1,15 +1,15 @@
 import React from 'react';
-import ProfileTab from '../../components/ProfileTab';
 import Bio from '../../components/Bio';
 import Review from '../../components/Review';
+import Tab from '../../components/Tab';
 
 export default function ProfileDeatil() {
   return (
     <div>
-      <ProfileTab>
+      <Tab>
         <Bio label="Bio" />
         <Review label="Review" />
-      </ProfileTab>
+      </Tab>
     </div>
   );
 }

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -9,14 +9,8 @@ export default function Profile() {
   const [userProfile, setUserProfile] = useState({});
   const { user } = useAuth();
 
-  const getUserProfile = () => {
-    getSingleProfile(user.uid).then(setUserProfile);
-  };
-
-  console.warn('profiles', userProfile);
-
   useEffect(() => {
-    getUserProfile();
+    getSingleProfile(user.uid).then(setUserProfile);
   }, [user.uid]);
 
   return (

--- a/pages/profile/[uid].js
+++ b/pages/profile/[uid].js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export default function ProfileDeatil() {
+export default function UserProfileDeatil() {
   return (
     <div>
       <p>detail page</p>

--- a/pages/profile/[uid].js
+++ b/pages/profile/[uid].js
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function ProfileDeatil() {
+  return (
+    <div>
+      <p>detail page</p>
+    </div>
+  );
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,5 +1,6 @@
 @import 'bootstrap/dist/css/bootstrap.css';
 @import url('https://fonts.googleapis.com/css2?family=Roboto&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,300;0,400;1,300;1,400&display=swap');
 
 
 html,
@@ -238,10 +239,119 @@ body {
   margin: 20px;
 }
 
-.tab-button:hover{
+.tab-button {
   border-bottom: 0; 
   border-radius: 8px 8px 0px 0px;
-  border-width: 1.8px !important; 
+  border-width: 2px !important; 
   border-color: black; 
   padding: 10px 15px;
+}
+
+.tab {
+  margin: 20px;
+  max-width: 1000px;
+  width: 50%;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+/* width: '40%', borderWidth: '1.8px', alignContent: 'center', display: 'block', marginLeft: 'auto', marginRight: 'auto', marginTop: '50px' */
+
+.tab .tab-headers {
+  display: flex;
+  flex-wrap: wrap;
+  border-bottom: 1.4px solid black;
+}
+
+.tab .tab-headers .tab-header {
+  position: relative;
+  padding: 0px 18px;
+  height: 40px;
+  line-height: 50px;
+  z-index: 2;
+  cursor: pointer;
+  color: #222;
+  border-radius: 8px 8px 0px 0px;
+  border-width: 1.4px !important;
+  font-family: Poppins, sans-serif;
+  font-weight: 300;
+}
+
+.hover-header:hover {
+  border-radius: 8px 8px 0px 0px;
+  background-color: rgb(207, 206, 206);
+
+}
+
+
+.tab .tab-headers .tab-header.active {
+  color: #4439f1;
+  border: 1px solid black;
+  border-bottom: none;
+  box-shadow: 0px 2px 0px #E5E5E5;
+  font-weight: 400;
+}
+
+.profile-detail-body {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  min-height: 100vh; 
+  box-sizing: border-box;
+}
+
+.profile-card {
+  display: flex;
+  align-items: center;
+  padding: 20px;
+  width: 100%;
+  max-width: 600px;
+  margin-bottom: 20px;
+  border-radius: 8px;
+}
+
+.profile-card__image {
+  border-radius: 50%;
+  width: 100px;
+  height: 100px;
+  margin-right: 20px;
+}
+
+.profile-card__text-container {
+  display: flex;
+  flex-direction: column;
+}
+
+.profile-card__name {
+  margin: 0;
+  font-size: 24px;
+  font-weight: 600;
+}
+
+.profile-card__skill {
+  margin: 5px 0 0 0;
+  font-size: 16px;
+  color: #555;
+}
+
+.profile-card__bio {
+  width: 100%;
+  max-width: 600px;
+  background-color: #fff;
+  padding: 20px;
+  border-radius: 8px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  margin-top: 20px; 
+  margin-bottom: 40px;
+}
+
+.profile-card__bio-content {
+  font-size: 16px;
+  color: #555;
+}
+
+.profile-card__bio-content p {
+  margin: 10px 0;
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -237,3 +237,11 @@ body {
 .input-form {
   margin: 20px;
 }
+
+.tab-button:hover{
+  border-bottom: 0; 
+  border-radius: 8px 8px 0px 0px;
+  border-width: 1.8px !important; 
+  border-color: black; 
+  padding: 10px 15px;
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -317,6 +317,7 @@ body {
   width: 100px;
   height: 100px;
   margin-right: 20px;
+  object-fit: cover;
 }
 
 .profile-card__text-container {
@@ -334,6 +335,10 @@ body {
   margin: 5px 0 0 0;
   font-size: 16px;
   color: #555;
+}
+
+.profile-card__location{
+  font-size: 13px
 }
 
 .profile-card__bio {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- DELETE ALL COMMENTS BEFORE CREATING PULL REQUEST -->

## Description
Created the tab component for the profile detail page. When clicking on view profile button on the profile cards a user will be routed to the detail page for that profile. Here a tab will appear that displays a tab with two option. Currently the 'Bio' tab is the only one that is finished 

## Related Issue
#10 

## Motivation and Context
It is required so a user will can learn more about the person by reading their bio. 

## How Can This Be Tested?
- Go to the Discover page
- Click on the 'View Profile' button
- You should see the users profile detail page with their bio
- You can also switch between the bio and review content
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
[ ] Bug fix (non-breaking change which fixes an issue)
[ x] New feature (non-breaking change which adds functionality)
[ ] Breaking change 
